### PR TITLE
Extracted subject management to Holder classes

### DIFF
--- a/PMVP.xcodeproj/project.pbxproj
+++ b/PMVP.xcodeproj/project.pbxproj
@@ -36,6 +36,14 @@
 		7E149300225D90E500A26743 /* ProviderBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1492FF225D90E500A26743 /* ProviderBase.swift */; };
 		7E6A6634226E6A070067F69B /* MockLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A6633226E6A070067F69B /* MockLocalStorage.swift */; };
 		7E6A6636226E6A410067F69B /* MockRemoteStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A6635226E6A410067F69B /* MockRemoteStorage.swift */; };
+		7E6A664C226FF1200067F69B /* KeyedSubjectHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A664B226FF1200067F69B /* KeyedSubjectHolder.swift */; };
+		7E6A664E226FF6070067F69B /* SubjectHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A664D226FF6070067F69B /* SubjectHolder.swift */; };
+		7E6A6650226FF7D90067F69B /* CollectionSubjectHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A664F226FF7D90067F69B /* CollectionSubjectHolder.swift */; };
+		7E6A6652226FF8FB0067F69B /* KeyedCollectionSubjectHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A6651226FF8FB0067F69B /* KeyedCollectionSubjectHolder.swift */; };
+		7EB4DE5A227014BD00EF2AFE /* SubjectHolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4DE59227014BD00EF2AFE /* SubjectHolderTests.swift */; };
+		7EB4DE5C2270166C00EF2AFE /* KeyedSubjectHolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4DE5B2270166C00EF2AFE /* KeyedSubjectHolderTests.swift */; };
+		7EB4DE5E2270182500EF2AFE /* CollectionSubjectHolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4DE5D2270182500EF2AFE /* CollectionSubjectHolderTests.swift */; };
+		7EB4DE60227019F800EF2AFE /* KeyedCollectionSubjectHolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4DE5F227019F800EF2AFE /* KeyedCollectionSubjectHolderTests.swift */; };
 		7ECC5C17226E2DB70015A91B /* Trackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECC5C16226E2DB70015A91B /* Trackable.swift */; };
 		87699565589E244EDB5A10C3 /* Pods_PMVPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFA91BD3B69C46666D69C570 /* Pods_PMVPTests.framework */; };
 /* End PBXBuildFile section */
@@ -82,6 +90,14 @@
 		7E1492FF225D90E500A26743 /* ProviderBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderBase.swift; sourceTree = "<group>"; };
 		7E6A6633226E6A070067F69B /* MockLocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalStorage.swift; sourceTree = "<group>"; };
 		7E6A6635226E6A410067F69B /* MockRemoteStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteStorage.swift; sourceTree = "<group>"; };
+		7E6A664B226FF1200067F69B /* KeyedSubjectHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedSubjectHolder.swift; sourceTree = "<group>"; };
+		7E6A664D226FF6070067F69B /* SubjectHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectHolder.swift; sourceTree = "<group>"; };
+		7E6A664F226FF7D90067F69B /* CollectionSubjectHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSubjectHolder.swift; sourceTree = "<group>"; };
+		7E6A6651226FF8FB0067F69B /* KeyedCollectionSubjectHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedCollectionSubjectHolder.swift; sourceTree = "<group>"; };
+		7EB4DE59227014BD00EF2AFE /* SubjectHolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectHolderTests.swift; sourceTree = "<group>"; };
+		7EB4DE5B2270166C00EF2AFE /* KeyedSubjectHolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedSubjectHolderTests.swift; sourceTree = "<group>"; };
+		7EB4DE5D2270182500EF2AFE /* CollectionSubjectHolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSubjectHolderTests.swift; sourceTree = "<group>"; };
+		7EB4DE5F227019F800EF2AFE /* KeyedCollectionSubjectHolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedCollectionSubjectHolderTests.swift; sourceTree = "<group>"; };
 		7ECC5C16226E2DB70015A91B /* Trackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trackable.swift; sourceTree = "<group>"; };
 		80A2D1D5FF16E625B78A517D /* Pods_PMVP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PMVP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A122AAE1F8EA9856A95506AB /* Pods-PMVP.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PMVP.release.xcconfig"; path = "Target Support Files/Pods-PMVP/Pods-PMVP.release.xcconfig"; sourceTree = "<group>"; };
@@ -161,6 +177,10 @@
 				7E1492E6225C3FC200A26743 /* Storage.swift */,
 				7E1492E8225C3FFE00A26743 /* AbstractObject.swift */,
 				7ECC5C16226E2DB70015A91B /* Trackable.swift */,
+				7E6A664B226FF1200067F69B /* KeyedSubjectHolder.swift */,
+				7E6A6651226FF8FB0067F69B /* KeyedCollectionSubjectHolder.swift */,
+				7E6A664D226FF6070067F69B /* SubjectHolder.swift */,
+				7E6A664F226FF7D90067F69B /* CollectionSubjectHolder.swift */,
 			);
 			path = PMVP;
 			sourceTree = "<group>";
@@ -168,6 +188,7 @@
 		7E1492C1225C342700A26743 /* PMVPTests */ = {
 			isa = PBXGroup;
 			children = (
+				7EB4DE58227014AC00EF2AFE /* Holders */,
 				7E1492EA225C490A00A26743 /* Example */,
 				7E1492C4225C342700A26743 /* Info.plist */,
 				7E1492F7225C4C3100A26743 /* ProviderTests.swift */,
@@ -199,6 +220,17 @@
 				7E6A6635226E6A410067F69B /* MockRemoteStorage.swift */,
 			);
 			path = Mock;
+			sourceTree = "<group>";
+		};
+		7EB4DE58227014AC00EF2AFE /* Holders */ = {
+			isa = PBXGroup;
+			children = (
+				7EB4DE59227014BD00EF2AFE /* SubjectHolderTests.swift */,
+				7EB4DE5B2270166C00EF2AFE /* KeyedSubjectHolderTests.swift */,
+				7EB4DE5D2270182500EF2AFE /* CollectionSubjectHolderTests.swift */,
+				7EB4DE5F227019F800EF2AFE /* KeyedCollectionSubjectHolderTests.swift */,
+			);
+			path = Holders;
 			sourceTree = "<group>";
 		};
 		C9FA2C101353B559835B354C /* Pods */ = {
@@ -405,8 +437,11 @@
 				7ECC5C17226E2DB70015A91B /* Trackable.swift in Sources */,
 				7E1492D3225C348D00A26743 /* ViewModel.swift in Sources */,
 				7E1492D5225C387E00A26743 /* Presenter.swift in Sources */,
+				7E6A664E226FF6070067F69B /* SubjectHolder.swift in Sources */,
 				7E1492E9225C3FFE00A26743 /* AbstractObject.swift in Sources */,
+				7E6A664C226FF1200067F69B /* KeyedSubjectHolder.swift in Sources */,
 				7E1492CF225C344600A26743 /* ViewModelState.swift in Sources */,
+				7E6A6650226FF7D90067F69B /* CollectionSubjectHolder.swift in Sources */,
 				7E1492E3225C3ECB00A26743 /* RemoteObject.swift in Sources */,
 				7E1492E7225C3FC200A26743 /* Storage.swift in Sources */,
 				7E1492DF225C3DEC00A26743 /* Converter.swift in Sources */,
@@ -415,6 +450,7 @@
 				7E1492DB225C3AC700A26743 /* LocalStorage.swift in Sources */,
 				7E1492E1225C3EA900A26743 /* LocalObject.swift in Sources */,
 				7E6A6636226E6A410067F69B /* MockRemoteStorage.swift in Sources */,
+				7E6A6652226FF8FB0067F69B /* KeyedCollectionSubjectHolder.swift in Sources */,
 				7E1492D7225C3A3C00A26743 /* Proxy.swift in Sources */,
 				7E1492E5225C3F5200A26743 /* RemoteStorage.swift in Sources */,
 			);
@@ -424,10 +460,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7EB4DE5C2270166C00EF2AFE /* KeyedSubjectHolderTests.swift in Sources */,
 				7E1492EC225C494400A26743 /* PlaylistProxy.swift in Sources */,
+				7EB4DE5E2270182500EF2AFE /* CollectionSubjectHolderTests.swift in Sources */,
 				7E1492FC225C4DB900A26743 /* PlaylistRemoteConverter.swift in Sources */,
 				7E1492F4225C4B7200A26743 /* PlaylistRemoteObject.swift in Sources */,
 				7E1492F6225C4BCE00A26743 /* PlaylistProvider.swift in Sources */,
+				7EB4DE5A227014BD00EF2AFE /* SubjectHolderTests.swift in Sources */,
 				7E1492FA225C4C9000A26743 /* PlaylistLocalConverter.swift in Sources */,
 				7E1492F8225C4C3100A26743 /* ProviderTests.swift in Sources */,
 				7E1492FE225D8FCB00A26743 /* ProviderRxTests.swift in Sources */,
@@ -435,6 +474,7 @@
 				7E149300225D90E500A26743 /* ProviderBase.swift in Sources */,
 				7E1492F2225C4B2F00A26743 /* PlaylistRemoteStorage.swift in Sources */,
 				7E1492F0225C4A3200A26743 /* Playlist.swift in Sources */,
+				7EB4DE60227019F800EF2AFE /* KeyedCollectionSubjectHolderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PMVP/CollectionSubjectHolder.swift
+++ b/PMVP/CollectionSubjectHolder.swift
@@ -1,0 +1,31 @@
+//
+//  CollectionSubjectHolder.swift
+//  PMVP
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import RxSwift
+
+open class CollectionSubjectHolder<T> {
+
+	private let collectionSubject: BehaviorSubject<[T]>
+
+	private let scheduler: SchedulerType
+
+	public init(scheduler: SchedulerType, preloader: (BehaviorSubject<[T]>) -> Void = { _ in }) {
+		self.scheduler = scheduler
+		self.collectionSubject = BehaviorSubject<[T]>(value: [])
+		preloader(collectionSubject)
+	}
+
+	public final func subject() -> Observable<[T]> {
+		return collectionSubject
+	}
+
+	public final func notify(_ objects: [T]) {
+		collectionSubject.onNext(objects)
+	}
+
+}

--- a/PMVP/KeyedCollectionSubjectHolder.swift
+++ b/PMVP/KeyedCollectionSubjectHolder.swift
@@ -1,0 +1,56 @@
+//
+//  KeyedCollectionSubjectHolder.swift
+//  PMVP
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import RxSwift
+
+open class KeyedCollectionSubjectHolder<K: Hashable, T> {
+
+	public var subjectMap: [K: BehaviorSubject<[T]>] = [:]
+
+	private let scheduler: SchedulerType
+
+	private let preloader: (K, BehaviorSubject<[T]>) -> Void
+
+	public init(scheduler: SchedulerType, preloader: @escaping (K, BehaviorSubject<[T]>) -> Void = { _,_ in }) {
+		self.scheduler = scheduler
+		self.preloader = preloader
+	}
+
+	public final func subject(for key: K) -> Observable<[T]> {
+		return findOrCreateSubject(for: key)
+	}
+
+	public final func notify(for key: K, objects: [T]) {
+		if let subject = subjectMap[key] {
+			subject.onNext(objects)
+		}
+	}
+
+	// MARK: - Private methods
+
+	private func findOrCreateSubject(for key: K) -> Observable<[T]> {
+		if let existing = subjectMap[key] {
+			return existing
+		}
+		else {
+			let newSubject = BehaviorSubject<[T]>(value: [])
+			preloader(key, newSubject)
+			subjectMap[key] = newSubject
+			return newSubject
+				.observeOn(scheduler)
+				.do(onDispose: { [weak self] in self?.clearInactiveSubject(for: key) })
+		}
+	}
+
+	private func clearInactiveSubject(for key: K) {
+		if let subject = subjectMap[key], !subject.hasObservers {
+			subjectMap.removeValue(forKey: key)
+		}
+	}
+
+}

--- a/PMVP/KeyedSubjectHolder.swift
+++ b/PMVP/KeyedSubjectHolder.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-open class KeyedSubjectHolder<K: Hashable, T: Proxy<K>> {
+open class KeyedSubjectHolder<K: Hashable, T> {
 
 	private var subjectMap: [K: BehaviorSubject<T?>] = [:]
 
@@ -25,8 +25,8 @@ open class KeyedSubjectHolder<K: Hashable, T: Proxy<K>> {
 		return findOrCreateSubject(for: key)
 	}
 
-	public final func notify(_ object: T) {
-		if let subject = subjectMap[object.key] {
+	public final func notify(for key: K, object: T) {
+		if let subject = subjectMap[key] {
 			subject.onNext(object)
 		}
 	}

--- a/PMVP/KeyedSubjectHolder.swift
+++ b/PMVP/KeyedSubjectHolder.swift
@@ -1,0 +1,56 @@
+//
+//  KeyedSubjectHolder.swift
+//  PMVP
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import RxSwift
+
+open class KeyedSubjectHolder<K: Hashable, T: Proxy<K>> {
+
+	private var subjectMap: [K: BehaviorSubject<T?>] = [:]
+
+	private let scheduler: SchedulerType
+
+	private let preloader: (K, BehaviorSubject<T?>) -> Void
+
+	public init(scheduler: SchedulerType, preloader: @escaping (K, BehaviorSubject<T?>) -> Void = { _,_ in }) {
+		self.scheduler = scheduler
+		self.preloader = preloader
+	}
+
+	public final func subject(for key: K) -> Observable<T?> {
+		return findOrCreateSubject(for: key)
+	}
+
+	public final func notify(_ object: T) {
+		if let subject = subjectMap[object.key] {
+			subject.onNext(object)
+		}
+	}
+
+	// MARK: - Private methods
+
+	private func findOrCreateSubject(for key: K) -> Observable<T?> {
+		if let existing = subjectMap[key] {
+			return existing
+		}
+		else {
+			let newSubject = BehaviorSubject<T?>(value: nil)
+			preloader(key, newSubject)
+			subjectMap[key] = newSubject
+			return newSubject
+				.observeOn(scheduler)
+				.do(onDispose: { [weak self] in self?.clearInactiveSubject(for: key) })
+		}
+	}
+
+	private func clearInactiveSubject(for key: K) {
+		if let subject = subjectMap[key], !subject.hasObservers {
+			subjectMap.removeValue(forKey: key)
+		}
+	}
+
+}

--- a/PMVP/Provider.swift
+++ b/PMVP/Provider.swift
@@ -10,17 +10,13 @@ import RxSwift
 
 open class Provider<K: Hashable, T: Proxy<K>, A: LocalObject, B: RemoteObject, L: LocalStorage<K, A, T>, R: RemoteStorage<K, B, T>> {
 
-	private let localStorage: LocalStorage<K, A, T>
+	public let localStorage: LocalStorage<K, A, T>
 
-	private let remoteStorage: RemoteStorage<K, B, T>
+	public let remoteStorage: RemoteStorage<K, B, T>
 
-	private let storageQueue: DispatchQueue
+	public let storageQueue: DispatchQueue
 
-	private let scheduler: SchedulerType
-
-	private var keysSubject: BehaviorSubject<[K]>!
-
-	public var collectionSubject: BehaviorSubject<[T]>!
+	public let scheduler: SchedulerType
 
 	private let subjectHolder: KeyedSubjectHolder<K, T>
 

--- a/PMVP/Provider.swift
+++ b/PMVP/Provider.swift
@@ -20,32 +20,38 @@ open class Provider<K: Hashable, T: Proxy<K>, A: LocalObject, B: RemoteObject, L
 
 	private var keysSubject: BehaviorSubject<[K]>!
 
-	private var collectionSubject: BehaviorSubject<[T]>!
+	public var collectionSubject: BehaviorSubject<[T]>!
 
-	private var subjectMap: [K: BehaviorSubject<T?>] = [:]
+	private let subjectHolder: KeyedSubjectHolder<K, T>
+
+	private let collectionHolder: CollectionSubjectHolder<T>
+
+	private let keysSubjectHolder: CollectionSubjectHolder<K>
 
 	public init(queueName: String, localStorage: LocalStorage<K, A, T>, remoteStorage: RemoteStorage<K, B, T>) {
-		self.storageQueue = DispatchQueue(label: queueName)
+		let queue = DispatchQueue(label: queueName)
+		self.storageQueue = queue
 		self.scheduler = SerialDispatchQueueScheduler(queue: storageQueue, internalSerialQueueName: queueName)
 		self.localStorage = localStorage
 		self.remoteStorage = remoteStorage
-		keysSubject = createKeyListSubject()
-		collectionSubject = createCollectionSubject()
+
+		let subjectPreloader: (K, BehaviorSubject<T?>) -> Void = { key, subject in
+			localStorage.object(for: key, queue: queue, callback: { (result) in subject.onNext(result) })
+		}
+		subjectHolder = KeyedSubjectHolder<K, T>(scheduler: scheduler, preloader: subjectPreloader)
+
+		let keyPreloader: (BehaviorSubject<[K]>) -> Void = { subject in
+			localStorage.allObjects(queue: queue, callback: { (results) in subject.onNext(results.map({ $0.key })) })
+		}
+		keysSubjectHolder = CollectionSubjectHolder<K>(scheduler: scheduler, preloader: keyPreloader)
+
+		let collectionPreloader: (BehaviorSubject<[T]>) -> Void = { subject in
+			localStorage.allObjects(queue: queue, callback: { (results) in subject.onNext(results) })
+		}
+		collectionHolder = CollectionSubjectHolder<T>(scheduler: scheduler, preloader: collectionPreloader)
 	}
 
 	// MARK: - Required Methods
-
-	open func createSubject() -> BehaviorSubject<T?> {
-		fatalError("unimplemented \(#function)")
-	}
-
-	open func createKeyListSubject() -> BehaviorSubject<[K]> {
-		fatalError("unimplemented \(#function)")
-	}
-
-	open func createCollectionSubject() -> BehaviorSubject<[T]> {
-		fatalError("unimplemented \(#function)")
-	}
 
 	// MARKL - Optional Methods
 
@@ -98,7 +104,7 @@ open class Provider<K: Hashable, T: Proxy<K>, A: LocalObject, B: RemoteObject, L
 			guard let strongSelf = self else {
 				fatalError("impossible")
 			}
-			result = strongSelf.keysSubject
+			result = strongSelf.keysSubjectHolder.subject()
 		}
 		return result
 	}
@@ -109,7 +115,7 @@ open class Provider<K: Hashable, T: Proxy<K>, A: LocalObject, B: RemoteObject, L
 			guard let strongSelf = self else {
 				fatalError("impossible")
 			}
-			result = strongSelf.collectionSubject
+			result = strongSelf.collectionHolder.subject()
 		}
 		return result
 	}
@@ -120,41 +126,23 @@ open class Provider<K: Hashable, T: Proxy<K>, A: LocalObject, B: RemoteObject, L
 			guard let strongSelf = self else {
 				fatalError("impossible")
 			}
-			result = strongSelf.findOrCreateSubject(for: key)
+			result = strongSelf.subjectHolder.subject(for: key).distinctUntilChanged()
 		}
 		return result
 	}
 
 	// MARK: - Private Helper Methods
 
-	private func findOrCreateSubject(for key: K) -> BehaviorSubject<T?> {
-		if let existingSubject: BehaviorSubject<T?> = subjectMap[key] {
-			return existingSubject
-		}
-		else {
-			let newSubject: BehaviorSubject<T?> = createSubject()
-			subjectMap[key] = newSubject
-			_ = newSubject
-				.observeOn(scheduler)
-				.do(onDispose: { [weak self] in self?.clearUnusedSubject(for: key) })
-			return newSubject
-		}
-	}
-
-	private func clearUnusedSubject(for key: K) {
-		if let subject: BehaviorSubject<T?> = subjectMap[key], !subject.hasObservers {
-			subjectMap.removeValue(forKey: key)
-		}
-	}
-
 	private func notify(_ object: T?) {
 		guard let key = object?.key else { return }
-		if let subject = subjectMap[key] {
+		let observable = subjectHolder.subject(for: key)
+		if let subject = observable as? BehaviorSubject<T?> {
 			subject.onNext(object)
 		}
+
 		if shouldNotifyAllOnUpdate() {
 			localStorage.allObjects(queue: storageQueue) { [weak self] (results) in
-				self?.collectionSubject.onNext(results)
+				self?.collectionHolder.notify(results)
 			}
 		}
 	}

--- a/PMVP/SubjectHolder.swift
+++ b/PMVP/SubjectHolder.swift
@@ -1,0 +1,31 @@
+//
+//  SubjectHolder.swift
+//  PMVP
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import RxSwift
+
+open class SubjectHolder<T> {
+
+	private let objectSubject: BehaviorSubject<T?>
+
+	private let scheduler: SchedulerType
+
+	public init(scheduler: SchedulerType, preloader: (BehaviorSubject<T?>) -> Void = { _ in }) {
+		self.scheduler = scheduler
+		self.objectSubject = BehaviorSubject<T?>(value: nil)
+		preloader(objectSubject)
+	}
+
+	public final func subject() -> BehaviorSubject<T?> {
+		return objectSubject
+	}
+
+	public final func notify(_ object: T?) {
+		objectSubject.onNext(object)
+	}
+
+}

--- a/PMVPTests/Example/PlaylistProvider.swift
+++ b/PMVPTests/Example/PlaylistProvider.swift
@@ -10,17 +10,4 @@ import RxSwift
 @testable import PMVP
 
 class PlaylistProvider: Provider<String, PlaylistProxy, Playlist, PlaylistRemoteObject, PlaylistLocalStorage, PlaylistRemoteStorage> {
-
-	override func createSubject() -> BehaviorSubject<PlaylistProxy?> {
-		return BehaviorSubject<PlaylistProxy?>(value: nil)
-	}
-
-	override func createCollectionSubject() -> BehaviorSubject<[PlaylistProxy]> {
-		return BehaviorSubject<[PlaylistProxy]>(value: [])
-	}
-
-	override func createKeyListSubject() -> BehaviorSubject<[String]> {
-		return BehaviorSubject<[String]>(value: [])
-	}
-
 }

--- a/PMVPTests/Holders/CollectionSubjectHolderTests.swift
+++ b/PMVPTests/Holders/CollectionSubjectHolderTests.swift
@@ -1,0 +1,36 @@
+//
+//  CollectionSubjectHolderTests.swift
+//  PMVPTests
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+@testable import PMVP
+
+class CollectionSubjectHolderTests: XCTestCase {
+
+	func testCollectionHolder() {
+		let holder = CollectionSubjectHolder<PlaylistProxy>(scheduler: MainScheduler.asyncInstance)
+		let emptyExp = expectation(description: "did receive empty")
+		let nonEmptyExp = expectation(description: "did receive non-empty")
+		let key = "playlist1"
+		let expectedValue = "newValue"
+		_ = holder.subject().subscribe(onNext: { actualValue in
+			if actualValue.isEmpty {
+				emptyExp.fulfill()
+			}
+			else {
+				XCTAssertEqual(actualValue.count, 1)
+				nonEmptyExp.fulfill()
+			}
+		})
+		let proxy = PlaylistProxy(id: key, name: expectedValue)
+		let results: [PlaylistProxy] = [proxy]
+		holder.notify(results)
+		waitForExpectations(timeout: 1.0, handler: nil)
+	}
+
+}

--- a/PMVPTests/Holders/KeyedCollectionSubjectHolderTests.swift
+++ b/PMVPTests/Holders/KeyedCollectionSubjectHolderTests.swift
@@ -1,0 +1,70 @@
+//
+//  KeyedCollectionSubjectHolderTests.swift
+//  PMVPTests
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+@testable import PMVP
+
+class KeyedCollectionSubjectHolderTests: XCTestCase {
+
+	func testKeyedCollectionHolder() {
+		let holder = KeyedCollectionSubjectHolder<String, PlaylistProxy>(scheduler: MainScheduler.asyncInstance)
+		let empty1Exp = expectation(description: "did receive empty1")
+		let nonEmpty1Exp = expectation(description: "did receive non-empty1")
+		let empty2Exp = expectation(description: "did receive empty2")
+		let nonEmpty2Exp = expectation(description: "did receive non-empty2")
+		let key1 = "playlist1"
+		let expectedValue1 = "newValue"
+		let key2 = "playlist2"
+		let expectedValue2 = "oldValue"
+
+		let d1 = holder.subject(for: key1).subscribe(onNext: { actualValue in
+			if actualValue.isEmpty {
+				empty1Exp.fulfill()
+			}
+			else {
+				nonEmpty1Exp.fulfill()
+				if let first = actualValue.first {
+					XCTAssertEqual(first.key, key1)
+					XCTAssertEqual(first.name, expectedValue1)
+				}
+			}
+		})
+
+		let d2 = holder.subject(for: key2).subscribe(onNext: { actualValue in
+			if actualValue.isEmpty {
+				empty2Exp.fulfill()
+			}
+			else {
+				nonEmpty2Exp.fulfill()
+				if let first = actualValue.first {
+					XCTAssertEqual(first.key, key2)
+					XCTAssertEqual(first.name, expectedValue2)
+				}
+			}
+		})
+
+		let proxy1 = PlaylistProxy(id: key1, name: expectedValue1)
+		holder.notify(for: key1, objects: [proxy1])
+		let proxy2 = PlaylistProxy(id: key2, name: expectedValue2)
+		holder.notify(for: key2, objects: [proxy2])
+		waitForExpectations(timeout: 1.0, handler: nil)
+
+		let d3 = holder.subject(for: key2).skip(1).subscribe(onNext: { _ in
+			XCTFail("unexpected value")
+		})
+
+		d1.dispose()
+		holder.notify(for: key1, objects: [])
+
+		d2.dispose()
+		d3.dispose()
+		holder.notify(for: key2, objects: [])
+	}
+
+}

--- a/PMVPTests/Holders/KeyedSubjectHolderTests.swift
+++ b/PMVPTests/Holders/KeyedSubjectHolderTests.swift
@@ -31,11 +31,11 @@ class KeyedSubjectHolderTests: XCTestCase {
 			XCTFail("unexpected value")
 		})
 		let proxy1 = PlaylistProxy(id: key, name: expectedValue)
-		holder.notify(proxy1)
+		holder.notify(for: key, object: proxy1)
 		d2.dispose()
 
 		let proxy2 = PlaylistProxy(id: "playlist2", name: "Another Playlist")
-		holder.notify(proxy2)
+		holder.notify(for: "playlist2", object: proxy2)
 		waitForExpectations(timeout: 1.0, handler: nil)
 	}
 

--- a/PMVPTests/Holders/KeyedSubjectHolderTests.swift
+++ b/PMVPTests/Holders/KeyedSubjectHolderTests.swift
@@ -1,0 +1,42 @@
+//
+//  KeyedSubjectHolderTests.swift
+//  PMVPTests
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+@testable import PMVP
+
+class KeyedSubjectHolderTests: XCTestCase {
+
+	func testKeyedHolder() {
+		let holder = KeyedSubjectHolder<String, PlaylistProxy>(scheduler: MainScheduler.asyncInstance)
+		let nilExp = expectation(description: "did receive nil")
+		let nonNilExp = expectation(description: "did receive non-nil")
+		let key = "playlist1"
+		let expectedValue = "newValue"
+		_ = holder.subject(for: key).subscribe(onNext: { actualValue in
+			if let actualValue = actualValue {
+				XCTAssertEqual(actualValue.name, expectedValue)
+				nonNilExp.fulfill()
+			}
+			else {
+				nilExp.fulfill()
+			}
+		})
+		let d2 = holder.subject(for: "playlist2").skip(1).subscribe(onNext: { _ in
+			XCTFail("unexpected value")
+		})
+		let proxy1 = PlaylistProxy(id: key, name: expectedValue)
+		holder.notify(proxy1)
+		d2.dispose()
+
+		let proxy2 = PlaylistProxy(id: "playlist2", name: "Another Playlist")
+		holder.notify(proxy2)
+		waitForExpectations(timeout: 1.0, handler: nil)
+	}
+
+}

--- a/PMVPTests/Holders/SubjectHolderTests.swift
+++ b/PMVPTests/Holders/SubjectHolderTests.swift
@@ -1,0 +1,33 @@
+//
+//  SubjectHolderTests.swift
+//  PMVPTests
+//
+//  Created by Aubrey Goodman on 4/23/19.
+//  Copyright © 2019 Aubrey Goodman. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+@testable import PMVP
+
+class SubjectHolderTests: XCTestCase {
+
+    func testHolder() {
+		let holder = SubjectHolder<String>(scheduler: MainScheduler.asyncInstance)
+		let nilExp = expectation(description: "did receive nil")
+		let nonNilExp = expectation(description: "did receive non-nil")
+		let expectedValue = "newValue"
+		_ = holder.subject().subscribe(onNext: { actualValue in
+			if let actualValue = actualValue {
+				XCTAssertEqual(actualValue, expectedValue)
+				nonNilExp.fulfill()
+			}
+			else {
+				nilExp.fulfill()
+			}
+		})
+		holder.notify(expectedValue)
+		waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+}

--- a/PMVPTests/ProviderRxTests.swift
+++ b/PMVPTests/ProviderRxTests.swift
@@ -12,11 +12,11 @@ import RxSwift
 
 class ProviderRxTests: ProviderBase {
 
-    func testObservable() {
+    func testNewObjects() {
 		local.playlists = [:]
 
 		let emptyExp = expectation(description: "empty")
-		let d0 = provider.object(for: "playlist1").subscribe(onNext: { v0 in
+		_ = provider.object(for: "playlist1").subscribe(onNext: { v0 in
 			if v0 == nil {
 				emptyExp.fulfill()
 			}
@@ -26,7 +26,10 @@ class ProviderRxTests: ProviderBase {
 		})
 
 		wait(for: [emptyExp], timeout: 1.0)
-		d0.dispose()
+	}
+
+	func testEditObjects() {
+		local.playlists = [:]
 
 		let notEmptyExp = expectation(description: "no longer empty")
 		_ = provider.object(for: "playlist1").subscribe(onNext: { v1 in
@@ -45,5 +48,24 @@ class ProviderRxTests: ProviderBase {
 
 		wait(for: [notEmptyExp, updatedExp], timeout: 1.0)
     }
+
+	func testExisting() {
+		let key = "playlist1"
+		let name = "Playlist 1"
+		var existingData: [String: PlaylistProxy] = [:]
+		existingData[key] = PlaylistProxy(id: key, name: name)
+		local.playlists = existingData
+
+		let existingExp = expectation(description: "existing")
+		_ = provider.object(for: key).subscribe(onNext: { v0 in
+			if let v0 = v0 {
+				XCTAssertEqual(v0.key, key)
+				XCTAssertEqual(v0.name, name)
+				existingExp.fulfill()
+			}
+		})
+
+		wait(for: [existingExp], timeout: 1.0)
+	}
 
 }

--- a/PMVPTests/ProviderTests.swift
+++ b/PMVPTests/ProviderTests.swift
@@ -79,9 +79,13 @@ class ProviderTests: ProviderBase {
 			local.playlists[p.key] = p
 		}
 		let response = expectation(description: "received")
-		var updatedList = [PlaylistProxy](local.playlists.values)
-		updatedList[0].name = "example6"
-		updatedList[1].name = "example7"
+		var map: [String: PlaylistProxy] = [:]
+		for k in (1...2) {
+			map["playlist\(k)"] = local.playlists["playlist\(k)"]
+		}
+		map["playlist1"]?.name = "example6"
+		map["playlist2"]?.name = "example7"
+		var updatedList = [PlaylistProxy](map.values)
 		provider.update(updatedList, queue: .global()) { (results) in
 			XCTAssertEqual(results.count, 2)
 			if let first = results.first {


### PR DESCRIPTION
It became awkward to work with foreign key collections, due to some tight couplings in the generic code responsible for managing keyed subjects. As a result, this change extracts subject management into four generic classes, one for each of the following:

- SubjectHolder, represents an optional instance subject.
- KeyedSubjectHolder, represents a map of subjects, based on the object's key.
- CollectionSubjectHolder, represents a collection subject.
- KeyedCollectionSubjectHolder, represents a map of collections, based on a foreign key.
