### PR TITLE
Nanoservice with tests

### DIFF
--- a/kmp/pmvp/pmvp-nano/build.gradle.kts
+++ b/kmp/pmvp/pmvp-nano/build.gradle.kts
@@ -1,0 +1,9 @@
+applyMultiplatform()
+applyMavenPublish(group = "org.pmvp.nano", name = name, version = "0.0.1")
+
+commonDependencies {
+    implementation(project(":kmp:pmvp:pmvp-library"))
+}
+
+// version notes
+// 0.0.1 - initial draft

--- a/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/JournalInterfaces.kt
+++ b/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/JournalInterfaces.kt
@@ -1,0 +1,19 @@
+package org.pmvp.nano
+
+interface JournalEntry<K, T> {
+    var op: String
+    var key: K
+    var effectiveAt: Double
+    var payload: T
+}
+
+interface JournalRequest<K, T> {
+    val since: Double
+    val entries: List<JournalEntry<K, T>>
+}
+
+interface JournalResult<K> {
+    val key: K
+    val code: JournalResultCode
+    val message: String?
+}

--- a/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/JournalResponse.kt
+++ b/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/JournalResponse.kt
@@ -1,0 +1,17 @@
+package org.pmvp.nano
+
+import org.pmvp.Proxy
+
+data class JournalResponse<K, T: Proxy<K>>(
+        val status: List<JournalResult<K>>,
+        val records: List<T>
+)
+
+enum class JournalResultCode(val rawValue: Int) {
+    SUCCESS(0),
+    ALREADY_CREATED(1),
+    NOT_FOUND(2),
+    OUTDATED_UPDATE(3),
+    ALREADY_DELETED(4),
+    UNKNOWN(5)
+}

--- a/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/Nanoservice.kt
+++ b/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/Nanoservice.kt
@@ -1,0 +1,142 @@
+package org.pmvp.nano
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import org.pmvp.Proxy
+
+/**
+ * Nanoservice is responsible for receiving requests from mobile devices in service of
+ * synchronizing their data stores in an offline-first environment. Changes made by the mobile
+ * device are received and interpreted. Results from each row in the request are reported back to
+ * the client, along with any updates unknown to the client, such as changes made by other clients.
+ *
+ */
+class Nanoservice<K, T>(
+        private val queryable: Queryable<K, T>,
+        private val responseFactory: JournalResponseFactory<K, T>,
+        private val journalResultFactory: JournalResultFactory<K>,
+        private val modelFactory: ModelFactory<K, T>,
+        private val pageLimit: Int = 1000
+) : JournalService<K, T> where T : Proxy<K>, T : Updatable<T>, T : Creatable, T : Discardable<T> {
+
+    /**
+     * Primary method for processing requests.
+     *
+     * Fetches records matching the affected keys from the request. Then attempts to reconcile
+     * each entry in the request against the last known state of the record. Finally compiles a
+     * response object with the status of each entry, along with the next batch of records modified
+     * since the reference date specified in the request.
+     *
+     * @param request received from client, with record modification entries and a reference date.
+     * @return a cold [Flow] with a single [JournalResponse] payload.
+     */
+    override fun process(request: JournalRequest<K, T>): Flow<JournalResponse<K, T>> = flow {
+        // fetch records matching the affected keys
+        val existingMap = queryable.get(request.entries.map { it.key }).first()
+
+        // process submitted entries and update status
+        val status: List<JournalResult<K>> = request.entries.map { entry ->
+            when (entry.op) {
+                JournalType.CREATE.name -> createRecord(entry, existingMap)
+                JournalType.UPDATE.name -> updateRecord(entry, existingMap)
+                JournalType.DELETE.name -> deleteRecord(entry, existingMap)
+                else -> journalResultFactory.build(entry.key, JournalResultCode.UNKNOWN)
+            }
+        }
+
+        // fetch a batch of records modified since the request reference date
+        val responseRecords = queryable.records(request.since, limit = pageLimit).first()
+
+        // compile response
+        emit(
+                responseFactory.build(
+                        status = status,
+                        records = responseRecords
+                )
+        )
+    }
+
+    /**
+     * Delegate method responsible for attempting creation of a record.
+     *
+     * Checks the "existing records" map for a record matching the given key. If one exists, ignore
+     * the request. Otherwise, insert the new record.
+     */
+    private suspend fun createRecord(
+            entry: JournalEntry<K, T>,
+            existingMap: Map<K, T>
+    ): JournalResult<K> {
+        val found = existingMap[entry.key]
+        if (found == null) {
+            // not found; insert the new record
+            queryable.create(modelFactory.build(entry)).first()
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.SUCCESS)
+        } else {
+            // found existing; ignore entry
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.ALREADY_CREATED)
+        }
+    }
+
+    /**
+     * Delegate method responsible for attempting upsert of a record.
+     *
+     * Checks the "existing records" map for a record matching the given key. If a match is not
+     * found, the entry is ignored. If one exists, compare its `updatedAt` property against the
+     * entry `effectiveAt` property. Entries with values newer than the last known modification are
+     * updated; otherwise, the entry is ignored.
+     */
+    private suspend fun updateRecord(
+            entry: JournalEntry<K, T>,
+            existingMap: Map<K, T>
+    ): JournalResult<K> {
+        val found = existingMap[entry.key]
+        if (found == null) {
+            // not found; ignore entry
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.NOT_FOUND)
+        } else {
+            if (found.updatedAt < entry.effectiveAt) {
+                // entry is more recent; update record
+                val updatedModel = modelFactory.from(found, entry).copyWithUpdatedAt(entry.effectiveAt)
+                queryable.update(updatedModel).first()
+                return journalResultFactory.build(key = entry.key, code = JournalResultCode.SUCCESS)
+            } else {
+                // entry is older; ignore it
+                return journalResultFactory.build(key = entry.key, code = JournalResultCode.OUTDATED_UPDATE)
+            }
+        }
+    }
+
+    /**
+     * Delegate method responsible for attempting to discard a record.
+     *
+     * Checks the "existing records" map for a record matching the given key. If a match is not
+     * found, the entry is ignored. If a record is found with a non-null `discardedAt` value, the
+     * entry is ignored. Otherwise, the record is marked as discarded.
+     */
+    private suspend fun deleteRecord(
+            entry: JournalEntry<K, T>,
+            existingMap: Map<K, T>
+    ): JournalResult<K> {
+        val found: T? = existingMap[entry.key]
+        if (found == null) {
+            // not found; ignore entry
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.NOT_FOUND)
+        } else if (found.discardedAt != null) {
+            // found but already discarded; ignore entry
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.ALREADY_DELETED)
+        } else {
+            // mark as discarded and update
+            val discardedModel = modelFactory.from(found, entry).copyWithDiscardedAt(entry.effectiveAt)
+            queryable.update(discardedModel).first()
+            return journalResultFactory.build(key = entry.key, code = JournalResultCode.SUCCESS)
+        }
+    }
+
+    private enum class JournalType {
+        CREATE,
+        UPDATE,
+        DELETE
+    }
+
+}

--- a/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/Queryable.kt
+++ b/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/Queryable.kt
@@ -1,0 +1,44 @@
+package org.pmvp.nano
+
+import kotlinx.coroutines.flow.Flow
+import org.pmvp.Proxy
+
+/**
+ * Interface responsible for abstracting the persistent storage concerns using a standard method
+ * signature for fetching by key or by batch, inserting, and updating.
+ */
+interface Queryable<K, T>
+        where T: Proxy<K>,
+              T: Updatable<T>,
+              T: Creatable,
+              T: Discardable<T>
+{
+    /**
+     * Fetch records by primary key as a set
+     *
+     * @return a cold [Flow] with payload of a map of matching records
+     */
+    fun get(keys: List<K>): Flow<Map<K, T>>
+
+    /**
+     * Insert a new record
+     *
+     * @return a cold [Flow] of the inserted record
+     */
+    fun create(model: T): Flow<T>
+
+    /**
+     * Update an existing record; also used for discarding records by marking them with non-null
+     * value for `discardedAt`.
+     *
+     * @return a cold [Flow] of the updated record
+     */
+    fun update(model: T): Flow<T>
+
+    /**
+     * Fetch records where `updatedAt` is greater than the `since` argument.
+     *
+     * @return a cold [Flow] of the ordered list of any matching records
+     */
+    fun records(since: Double, limit: Int): Flow<List<T>>
+}

--- a/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/SupportInterfaces.kt
+++ b/kmp/pmvp/pmvp-nano/src/commonMain/kotlin/org/pmvp/nano/SupportInterfaces.kt
@@ -1,0 +1,35 @@
+package org.pmvp.nano
+
+import kotlinx.coroutines.flow.Flow
+import org.pmvp.Proxy
+
+interface Updatable<T> {
+    val updatedAt: Double
+    fun copyWithUpdatedAt(updatedAt: Double): T
+}
+
+interface Creatable {
+    val createdAt: Double
+}
+
+interface Discardable<T> {
+    val discardedAt: Double?
+    fun copyWithDiscardedAt(discardedAt: Double): T
+}
+
+interface JournalService<K, T: Proxy<K>> {
+    fun process(request: JournalRequest<K, T>): Flow<JournalResponse<K, T>>
+}
+
+interface JournalResultFactory<K> {
+    fun build(key: K, code: JournalResultCode, message: String? = null): JournalResult<K>
+}
+
+interface JournalResponseFactory<K, T: Proxy<K>> {
+    fun build(status: List<JournalResult<K>>, records: List<T>): JournalResponse<K, T>
+}
+
+interface ModelFactory<K, T> where T: Proxy<K>, T: Updatable<T>, T: Creatable {
+    fun build(entry: JournalEntry<K, T>): T
+    fun from(model: T, entry: JournalEntry<K, T>): T
+}

--- a/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemModel.kt
+++ b/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemModel.kt
@@ -1,0 +1,18 @@
+package org.pmvp.nano
+
+import org.pmvp.Proxy
+
+data class ItemModel(
+    override val key: String,
+    override val updatedAt: Double,
+    override val createdAt: Double,
+    override val discardedAt: Double?,
+    val name: String
+) : Proxy<String>, Updatable<ItemModel>, Creatable, Discardable<ItemModel> {
+    override fun copyWithUpdatedAt(updatedAt: Double): ItemModel =
+        copy(updatedAt = updatedAt)
+
+    override fun copyWithDiscardedAt(discardedAt: Double): ItemModel =
+        copy(discardedAt = discardedAt)
+
+}

--- a/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemNanoservice.kt
+++ b/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemNanoservice.kt
@@ -1,0 +1,61 @@
+package org.pmvp.nano
+
+import kotlinx.coroutines.InternalCoroutinesApi
+
+data class ItemJournalEntry(
+    override var op: String,
+    override var key: String,
+    override var effectiveAt: Double,
+    override var payload: ItemModel
+): JournalEntry<String, ItemModel>
+
+class ItemResponseFactory: JournalResponseFactory<String, ItemModel> {
+    override fun build(
+        status: List<JournalResult<String>>,
+        records: List<ItemModel>
+    ): JournalResponse<String, ItemModel> = JournalResponse(
+        status = status,
+        records = records
+    )
+}
+
+class ItemJournalResultFactory: JournalResultFactory<String> {
+    override fun build(key: String, code: JournalResultCode, message: String?): JournalResult<String> {
+        return ItemJournalResult(
+            key = key,
+            code = code,
+            message = message
+        )
+    }
+}
+
+data class ItemJournalResult(
+    override val key: String,
+    override val code: JournalResultCode,
+    override val message: String?
+) : JournalResult<String>
+
+class ItemRequest(
+    override val since: Double,
+    override val entries: List<JournalEntry<String, ItemModel>>
+) : JournalRequest<String, ItemModel>
+
+class ItemModelFactory: ModelFactory<String, ItemModel> {
+    override fun build(entry: JournalEntry<String, ItemModel>): ItemModel =
+        ItemModel(
+            key = entry.key,
+            name = entry.payload.name,
+            updatedAt = entry.effectiveAt,
+            createdAt = entry.effectiveAt,
+            discardedAt = null
+        )
+
+    override fun from(model: ItemModel, entry: JournalEntry<String, ItemModel>): ItemModel {
+        var result: ItemModel = model
+        entry.payload.name.let { result = result.copy(name = it) }
+        return result
+    }
+}
+
+@InternalCoroutinesApi
+typealias ItemNanoservice = Nanoservice<String, ItemModel>

--- a/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemNanoserviceTest.kt
+++ b/kmp/pmvp/pmvp-nano/src/jvmTest/kotlin/org/pmvp/nano/ItemNanoserviceTest.kt
@@ -1,0 +1,167 @@
+package org.pmvp.nano
+
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@InternalCoroutinesApi
+class ItemNanoserviceTest {
+
+    val pattern = "yyyy-M-dd'T'HH:mm:ss.SSSZ"
+
+    private fun buildItem(key: String, name: String, createdAt: Double, updatedAt: Double): ItemModel =
+        ItemModel(
+            key = key,
+            name = name,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            discardedAt = null
+        )
+
+    private class ItemQueryable(
+        private val map: MutableMap<String, ItemModel>
+    ): Queryable<String, ItemModel> {
+        override fun get(keys: List<String>): Flow<Map<String, ItemModel>> = flow {
+            val result: Map<String, ItemModel> = hashMapOf<String, ItemModel>().apply {
+                keys.forEach { key -> map[key]?.let { put(key, it) } }
+            }
+            emit(result)
+        }
+
+        override fun create(model: ItemModel): Flow<ItemModel> = flow {
+            map.put(model.key, model)
+            emit(model)
+        }
+
+        override fun update(model: ItemModel): Flow<ItemModel> = flow {
+            map.put(model.key, model)
+            emit(model)
+        }
+
+        override fun records(since: Double, limit: Int): Flow<List<ItemModel>> = flow {
+            val limitedEntries = map.values
+                .filter { it.updatedAt > since }
+                .sortedBy { it.updatedAt }
+                .take(limit)
+            emit(limitedEntries)
+        }
+
+        fun all(): Flow<List<ItemModel>> = flow {
+            emit(map.values.toList())
+        }
+    }
+
+    private fun buildNanoservice(itemQueryable: Queryable<String, ItemModel>) =
+            ItemNanoservice(
+                    queryable = itemQueryable,
+                    responseFactory = ItemResponseFactory(),
+                    journalResultFactory = ItemJournalResultFactory(),
+                    modelFactory = ItemModelFactory()
+            )
+
+    @Test
+    fun testEmptyRequest() = runBlocking {
+        val service = buildNanoservice(ItemQueryable(hashMapOf()))
+        val now = 1508675309.0
+        val request = ItemRequest(
+            since = now,
+            entries = emptyList()
+        )
+        val response = service.process(request).first()
+        assertEquals(0, response.status.count(), "wrong status count")
+        assertEquals(0, response.records.count(), "wrong records count")
+    }
+
+    @Test
+    fun testCreateNonConflictingRequest() = runBlocking {
+        val d1 = 1508675309.0
+        val existing = buildItem("item1", "Item1", d1, d1)
+
+        val itemQueryable = ItemQueryable(hashMapOf(existing.key to existing))
+        val service = buildNanoservice(itemQueryable)
+
+        val d2 = 1508675310.0
+        val request = ItemRequest(
+            since = d1,
+            entries = listOf(
+                ItemJournalEntry(
+                    op = "CREATE",
+                    key = "field2",
+                    effectiveAt = d2,
+                    payload = existing.copy(name = "Item2")
+                )
+            )
+        )
+        val response = service.process(request).first()
+        assertEquals(1, response.status.count(), "wrong status count")
+        assertEquals(1, response.records.count(), "wrong records count")
+        val stored = itemQueryable.all().first().filter { it.updatedAt > request.since }
+        assertEquals(1, stored.count(), "wrong stored count")
+        val stored1 = stored.first()
+        assertEquals("Item2", stored1.name, "wrong name")
+    }
+
+    @Test
+    fun testUpdateNonConflictingRequest() = runBlocking {
+        val d1 = 1508675309.0
+        val existing = buildItem("item1", "Item1", d1, d1)
+
+        val itemQueryable = ItemQueryable(hashMapOf(existing.key to existing))
+        val service = buildNanoservice(itemQueryable)
+
+        val d2 = 1508675310.0
+        val request = ItemRequest(
+            since = existing.updatedAt,
+            entries = listOf(
+                ItemJournalEntry(
+                    op = "UPDATE",
+                    key = existing.key,
+                    effectiveAt = d2,
+                    payload = existing.copy(name = "Item2")
+                )
+            )
+        )
+        val response = service.process(request).first()
+        assertEquals(1, response.status.count(), "wrong status count")
+        assertEquals(1, response.records.count(), "wrong record count")
+        val first = response.records.first()
+        assertEquals("Item2", first.name, "wrong name")
+        assertEquals(d2, first.updatedAt, "wrong updatedAt")
+    }
+
+    @Test
+    fun testUpdateConflictingOutdatedRequest() = runBlocking {
+        val d1 = 1508675309.0
+        val existing = buildItem("field1", "Item1", d1, d1.plus(10000))
+
+        val itemQueryable = ItemQueryable(hashMapOf(existing.key to existing))
+        val service = buildNanoservice(itemQueryable)
+
+        val d2 = 1508675309.0
+        val request = ItemRequest(
+            since = d1,
+            entries = listOf(
+                ItemJournalEntry(
+                    op = "UPDATE",
+                    key = existing.key,
+                    effectiveAt = d2,
+                    payload = existing.copy(name = "Item2")
+                )
+            )
+        )
+        val response = service.process(request).first()
+        assertEquals(1, response.status.count(), "wrong status count")
+        val status = response.status.first()
+        assertEquals(JournalResultCode.OUTDATED_UPDATE, status.code, "should error")
+        assertEquals(1, response.records.count(), "wrong record count")
+        val first = response.records.first()
+        assertEquals("Item1", first.name, "should ignore the request")
+        assertEquals(existing.updatedAt, first.updatedAt, "wrong updatedAt")
+    }
+
+}

--- a/kmp/pmvp/pmvp-nano/src/main/AndroidManifest.xml
+++ b/kmp/pmvp/pmvp-nano/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.pmvp.nano" />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 include(":kmp:pmvp:pmvp-ktor")
 include(":kmp:pmvp:pmvp-library")
-//include(":kmp:pmvp:pmvp-nano")
+include(":kmp:pmvp:pmvp-nano")
 include(":kmp:pmvp:pmvp-sqldelight")
 include(":kmp:pmvp:pmvp-view")


### PR DESCRIPTION
Nanoservice is intended to be deployed in a serverless environment to facilitate mobile sync for multiple clients. It processes requests for an arbitrary domain object adhering to a constrained generic type. Includes tests for simple considerations, such as conflict resolution scenarios.